### PR TITLE
Removed extra brace from acceptance test

### DIFF
--- a/src/main/groovy/com/redhat/ose/jenkins/job/OseWorkflowJob.groovy
+++ b/src/main/groovy/com/redhat/ose/jenkins/job/OseWorkflowJob.groovy
@@ -251,8 +251,6 @@ class OseWorkflowJob {
 	
 				}
 	
-			}
-	
 				"""
 			
 			acceptanceStep 


### PR DESCRIPTION
Removed an extra brace from the acceptance test step which was using parsing failures

@JaredBurck would you be able to review
